### PR TITLE
ci: skip build for docs-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,26 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+      - "ROADMAP.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - "CODEOWNERS"
+      - "CONTRIBUTING.md"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "*.md"
+      - "docs/**"
+      - "ROADMAP.md"
+      - "LICENSE"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - "CODEOWNERS"
+      - "CONTRIBUTING.md"
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
Adds paths-ignore filters so pushes/PRs that only touch markdown, docs, templates, or CODEOWNERS don't burn Actions minutes. Tag pushes (releases) still always trigger the full pipeline.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Tests only
- [ ] Documentation
- [x] CI / build / chore
- [ ] Breaking change (tick this AND one of the above)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My branch targets `main`
- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes with no new violations (`uv run ruff check src tests`)
- [x] New behaviour is covered by tests
- [x] Docstrings follow Google style on all new/modified public functions
- [x] Type annotations are present on all new public functions
