### PR TITLE
fix: block file:// and other non-HTTP URL schemes (SSRF)

### DIFF
--- a/src/feed_import.py
+++ b/src/feed_import.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import feedparser
 
 from src.models import Feed
+from src.url_validation import validate_feed_url
 
 
 def import_opml(path: str | Path) -> list[Feed]:
@@ -48,7 +49,7 @@ def _collect_opml_outlines(element: ET.Element, feeds: list[Feed]) -> None:
     """
     for outline in element.iter("outline"):
         xml_url = outline.get("xmlUrl")
-        if xml_url:
+        if xml_url and validate_feed_url(xml_url) is None:
             name = outline.get("title") or outline.get("text") or xml_url
             feeds.append(Feed(url=xml_url, name=name))
 

--- a/src/feed_poller.py
+++ b/src/feed_poller.py
@@ -18,6 +18,7 @@ from PySide6.QtCore import QThread, Signal
 
 from src.credential_store import get_credentials
 from src.models import Feed, FeedEntry
+from src.url_validation import validate_feed_url
 
 if TYPE_CHECKING:
     pass
@@ -142,6 +143,11 @@ class FeedPoller(QThread):
         Raises:
             ValueError: If auth credentials exist but the URL is not HTTPS.
         """
+        url_error = validate_feed_url(feed.url)
+        if url_error:
+            self.feed_error.emit(feed.url, url_error)
+            return feedparser.parse("")
+
         creds = get_credentials(feed.url)
         if creds:
             if not feed.url.startswith("https://"):

--- a/src/url_validation.py
+++ b/src/url_validation.py
@@ -1,0 +1,33 @@
+"""URL validation utilities for Jinkies feed monitor.
+
+Validates feed URLs against an allowlist of safe schemes
+to prevent SSRF and local file disclosure attacks.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+_ALLOWED_SCHEMES = {"http", "https"}
+
+
+def validate_feed_url(url: str) -> str | None:
+    """Validate a feed URL against the allowed scheme allowlist.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        An error message if invalid, or None if the URL is acceptable.
+    """
+    if not url or not url.strip():
+        return "URL must not be empty."
+    parsed = urlparse(url)
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        return (
+            f"URL scheme '{parsed.scheme or ''}' is not allowed. "
+            "Only http:// and https:// feed URLs are supported."
+        )
+    if not parsed.netloc:
+        return "URL must include a hostname."
+    return None

--- a/tests/test_url_validation.py
+++ b/tests/test_url_validation.py
@@ -1,0 +1,51 @@
+"""Tests for src.url_validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.url_validation import validate_feed_url
+
+
+class TestValidateFeedUrl:
+    @pytest.mark.parametrize("url", [
+        "https://example.com/feed.atom",
+        "https://jenkins.local:8443/rssAll",
+        "http://example.com/feed.xml",
+        "http://192.168.1.1/rss",
+    ])
+    def test_valid_urls(self, url):
+        assert validate_feed_url(url) is None
+
+    @pytest.mark.parametrize("url", [
+        "file:///etc/passwd",
+        "file:///home/user/.ssh/id_rsa",
+        "data:text/xml,<feed/>",
+        "javascript:alert(1)",
+        "ftp://example.com/feed.xml",
+        "gopher://example.com/",
+    ])
+    def test_blocked_schemes(self, url):
+        error = validate_feed_url(url)
+        assert error is not None
+        assert "not allowed" in error
+
+    def test_empty_string(self):
+        error = validate_feed_url("")
+        assert error is not None
+        assert "empty" in error.lower()
+
+    def test_whitespace_only(self):
+        error = validate_feed_url("   ")
+        assert error is not None
+        assert "empty" in error.lower()
+
+    def test_no_scheme(self):
+        error = validate_feed_url("example.com/feed")
+        assert error is not None
+        assert "not allowed" in error
+
+    def test_scheme_only_no_host(self):
+        error = validate_feed_url("https://")
+        assert error is not None
+        assert "hostname" in error.lower()


### PR DESCRIPTION
## Summary
- Adds URL scheme validation (`http`/`https` allowlist) to prevent local file disclosure via `file://`, `data://`, and other dangerous URL schemes
- Validation enforced at three layers: feed poller, feed edit dialog, and OPML/XML import
- New `src/url_validation.py` module with `validate_feed_url()` utility

## Test plan
- [x] 14 new tests covering valid URLs, blocked schemes, empty/malformed URLs
- [x] Feed poller tests verify `file://` and `data:` URLs emit errors
- [x] All 27 poller + validation tests passing
- [x] Existing feed import tests still pass
- [x] CI lint-and-test passing
- [x] CI builds passing (Linux, macOS, Windows)

Closes #19