### PR TITLE
fix: move credentials to OS keyring, block auth over HTTP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "feedparser>=6.0.12",
+    "keyring>=25.0.0",
     "pyside6>=6.10.2",
 ]
 

--- a/src/credential_store.py
+++ b/src/credential_store.py
@@ -1,0 +1,99 @@
+"""Secure credential storage for Jinkies feed monitor.
+
+Stores HTTP Basic auth credentials in the OS keyring instead of
+plaintext config files. Enforces HTTPS-only for authenticated feeds
+as defense-in-depth against credential leakage.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import keyring
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_PREFIX = "jinkies"
+
+
+def _service_name(feed_url: str) -> str:
+    """Build the keyring service name for a feed URL.
+
+    Args:
+        feed_url: The feed URL to derive a service name from.
+
+    Returns:
+        A service name in the form ``jinkies:<feed_url>``.
+    """
+    return f"{_SERVICE_PREFIX}:{feed_url}"
+
+
+def _require_https(feed_url: str) -> None:
+    """Validate that the feed URL uses HTTPS.
+
+    Args:
+        feed_url: The URL to validate.
+
+    Raises:
+        ValueError: If the URL does not start with ``https://``.
+    """
+    if not feed_url.startswith("https://"):
+        msg = (
+            f"Refusing to store credentials for non-HTTPS URL: {feed_url}. "
+            "Credentials must only be sent over encrypted connections."
+        )
+        raise ValueError(msg)
+
+
+def store_credentials(feed_url: str, username: str, token: str) -> None:
+    """Store authentication credentials in the OS keyring.
+
+    Args:
+        feed_url: The feed URL the credentials belong to.
+        username: The HTTP Basic auth username.
+        token: The HTTP Basic auth token/password.
+
+    Raises:
+        ValueError: If the feed URL is not HTTPS.
+    """
+    _require_https(feed_url)
+    service = _service_name(feed_url)
+    keyring.set_password(service, "username", username)
+    keyring.set_password(service, "token", token)
+    logger.debug("Stored credentials for %s", feed_url)
+
+
+def get_credentials(feed_url: str) -> tuple[str, str] | None:
+    """Retrieve authentication credentials from the OS keyring.
+
+    Args:
+        feed_url: The feed URL to look up credentials for.
+
+    Returns:
+        A ``(username, token)`` tuple, or ``None`` if no credentials
+        are stored for this feed.
+    """
+    service = _service_name(feed_url)
+    username = keyring.get_password(service, "username")
+    token = keyring.get_password(service, "token")
+    if username and token:
+        return (username, token)
+    return None
+
+
+def delete_credentials(feed_url: str) -> None:
+    """Remove authentication credentials from the OS keyring.
+
+    Args:
+        feed_url: The feed URL whose credentials should be deleted.
+    """
+    service = _service_name(feed_url)
+    try:
+        keyring.delete_password(service, "username")
+    except keyring.errors.PasswordDeleteError:
+        pass
+    try:
+        keyring.delete_password(service, "token")
+    except keyring.errors.PasswordDeleteError:
+        pass
+    logger.debug("Deleted credentials for %s", feed_url)

--- a/src/models.py
+++ b/src/models.py
@@ -35,6 +35,10 @@ class Feed:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-compatible dictionary.
 
+        Credentials are never written to the config file.  Instead a
+        ``has_auth`` flag indicates whether credentials are stored in
+        the OS keyring.
+
         Returns:
             Dictionary representation of this Feed.
         """
@@ -44,13 +48,17 @@ class Feed:
             "enabled": self.enabled,
             "sound_file": self.sound_file,
             "last_poll_time": self.last_poll_time,
-            "auth_user": self.auth_user,
-            "auth_token": self.auth_token,
+            "has_auth": bool(self.auth_user and self.auth_token),
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Feed:
         """Deserialize from a dictionary.
+
+        Handles both legacy configs (with plaintext ``auth_user``/
+        ``auth_token``) and new configs (with ``has_auth`` flag).
+        Legacy plaintext credentials are preserved in the dataclass
+        fields so that ``load_config`` can migrate them to the keyring.
 
         Args:
             data: Dictionary with feed fields.

--- a/tests/test_credential_store.py
+++ b/tests/test_credential_store.py
@@ -1,0 +1,94 @@
+"""Tests for src.credential_store."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.credential_store import (
+    _service_name,
+    delete_credentials,
+    get_credentials,
+    store_credentials,
+)
+
+
+class TestServiceName:
+    def test_service_name_format(self):
+        assert _service_name("https://example.com/feed") == "jinkies:https://example.com/feed"
+
+
+class TestStoreCredentials:
+    @patch("src.credential_store.keyring")
+    def test_store_credentials_https(self, mock_keyring):
+        store_credentials("https://example.com/feed", "user", "token123")
+
+        assert mock_keyring.set_password.call_count == 2
+        mock_keyring.set_password.assert_any_call(
+            "jinkies:https://example.com/feed", "username", "user",
+        )
+        mock_keyring.set_password.assert_any_call(
+            "jinkies:https://example.com/feed", "token", "token123",
+        )
+
+    def test_store_credentials_http_rejected(self):
+        with pytest.raises(ValueError, match="non-HTTPS"):
+            store_credentials("http://example.com/feed", "user", "token123")
+
+    def test_store_credentials_no_scheme_rejected(self):
+        with pytest.raises(ValueError, match="non-HTTPS"):
+            store_credentials("example.com/feed", "user", "token123")
+
+
+class TestGetCredentials:
+    @patch("src.credential_store.keyring")
+    def test_get_existing_credentials(self, mock_keyring):
+        mock_keyring.get_password.side_effect = lambda svc, key: {
+            ("jinkies:https://example.com/feed", "username"): "user",
+            ("jinkies:https://example.com/feed", "token"): "token123",
+        }.get((svc, key))
+
+        result = get_credentials("https://example.com/feed")
+        assert result == ("user", "token123")
+
+    @patch("src.credential_store.keyring")
+    def test_get_missing_credentials(self, mock_keyring):
+        mock_keyring.get_password.return_value = None
+
+        result = get_credentials("https://example.com/feed")
+        assert result is None
+
+    @patch("src.credential_store.keyring")
+    def test_get_partial_credentials_returns_none(self, mock_keyring):
+        mock_keyring.get_password.side_effect = lambda svc, key: {
+            ("jinkies:https://example.com/feed", "username"): "user",
+            ("jinkies:https://example.com/feed", "token"): None,
+        }.get((svc, key))
+
+        result = get_credentials("https://example.com/feed")
+        assert result is None
+
+
+class TestDeleteCredentials:
+    @patch("src.credential_store.keyring")
+    def test_delete_existing_credentials(self, mock_keyring):
+        delete_credentials("https://example.com/feed")
+
+        assert mock_keyring.delete_password.call_count == 2
+        mock_keyring.delete_password.assert_any_call(
+            "jinkies:https://example.com/feed", "username",
+        )
+        mock_keyring.delete_password.assert_any_call(
+            "jinkies:https://example.com/feed", "token",
+        )
+
+    @patch("src.credential_store.keyring")
+    def test_delete_nonexistent_credentials(self, mock_keyring):
+        import keyring.errors
+
+        mock_keyring.delete_password.side_effect = keyring.errors.PasswordDeleteError
+        mock_keyring.errors = keyring.errors
+
+        # Should not raise
+        delete_credentials("https://example.com/feed")

--- a/tests/test_feed_poller.py
+++ b/tests/test_feed_poller.py
@@ -40,9 +40,10 @@ class TestFeedPoller:
         poller.update_interval(120)
         assert poller.poll_interval == 120
 
+    @patch("src.feed_poller.get_credentials", return_value=None)
     @patch("src.feed_poller.feedparser.parse")
     def test_poll_feed_emits_new_entries(
-        self, mock_parse, sample_feed, mock_feedparser_result, qtbot,
+        self, mock_parse, _mock_creds, sample_feed, mock_feedparser_result, qtbot,
     ):
         mock_parse.return_value = mock_feedparser_result
         poller = FeedPoller(feeds=[sample_feed])
@@ -55,9 +56,10 @@ class TestFeedPoller:
         assert entries[0].title == "First Entry"
         assert entries[1].title == "Second Entry"
 
+    @patch("src.feed_poller.get_credentials", return_value=None)
     @patch("src.feed_poller.feedparser.parse")
     def test_poll_feed_skips_seen_entries(
-        self, mock_parse, sample_feed, mock_feedparser_result, qtbot,
+        self, mock_parse, _mock_creds, sample_feed, mock_feedparser_result, qtbot,
     ):
         mock_parse.return_value = mock_feedparser_result
         poller = FeedPoller(feeds=[sample_feed], seen_ids={"entry-1"})
@@ -69,8 +71,9 @@ class TestFeedPoller:
         assert len(entries) == 1
         assert entries[0].entry_id == "entry-2"
 
+    @patch("src.feed_poller.get_credentials", return_value=None)
     @patch("src.feed_poller.feedparser.parse")
-    def test_poll_feed_error(self, mock_parse, sample_feed, qtbot):
+    def test_poll_feed_error(self, mock_parse, _mock_creds, sample_feed, qtbot):
         mock_parse.side_effect = Exception("Network error")
         poller = FeedPoller(feeds=[sample_feed])
 
@@ -82,8 +85,9 @@ class TestFeedPoller:
         assert errors[0][0] == sample_feed.url
         assert "Network error" in errors[0][1]
 
+    @patch("src.feed_poller.get_credentials", return_value=None)
     @patch("src.feed_poller.feedparser.parse")
-    def test_poll_feed_bozo_error(self, mock_parse, sample_feed, qtbot):
+    def test_poll_feed_bozo_error(self, mock_parse, _mock_creds, sample_feed, qtbot):
         result = MagicMock()
         result.bozo = True
         result.entries = []
@@ -108,3 +112,62 @@ class TestFeedPoller:
                 if f.enabled:
                     poller._poll_feed(f)
             poller._poll_feed.assert_not_called()
+
+
+class TestFeedPollerAuth:
+    """Tests for credential lookup and HTTP rejection in feed polling."""
+
+    @patch("src.feed_poller.get_credentials", return_value=("user", "pass"))
+    def test_http_url_with_auth_emits_error(self, _mock_creds, qtbot):
+        """Credentials over plain HTTP must be rejected."""
+        feed = Feed(url="http://insecure.example.com/feed", name="Insecure")
+        poller = FeedPoller(feeds=[feed])
+
+        errors = []
+        poller.feed_error.connect(lambda url, msg: errors.append((url, msg)))
+        poller._poll_feed(feed)
+
+        assert len(errors) == 1
+        assert errors[0][0] == feed.url
+        assert "insecure HTTP" in errors[0][1]
+
+    @patch("src.feed_poller.urllib.request.urlopen")
+    @patch("src.feed_poller.get_credentials", return_value=("user", "token123"))
+    @patch("src.feed_poller.feedparser.parse")
+    def test_https_url_with_auth_succeeds(
+        self, mock_parse, _mock_creds, mock_urlopen, mock_feedparser_result, qtbot,
+    ):
+        """Credentials over HTTPS should be sent via Basic auth."""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"<feed></feed>"
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+        mock_parse.return_value = mock_feedparser_result
+
+        feed = Feed(url="https://secure.example.com/feed", name="Secure")
+        poller = FeedPoller(feeds=[feed])
+
+        entries = []
+        poller.new_entries_found.connect(entries.extend)
+        poller._poll_feed(feed)
+
+        # feedparser.parse was called with the fetched content
+        mock_parse.assert_called_once_with(b"<feed></feed>")
+        assert len(entries) == 2
+
+    @patch("src.feed_poller.get_credentials", return_value=None)
+    @patch("src.feed_poller.feedparser.parse")
+    def test_no_auth_http_url_allowed(
+        self, mock_parse, _mock_creds, mock_feedparser_result, qtbot,
+    ):
+        """HTTP URLs without auth should still work (no credentials at risk)."""
+        mock_parse.return_value = mock_feedparser_result
+        feed = Feed(url="http://example.com/feed", name="Public")
+        poller = FeedPoller(feeds=[feed])
+
+        entries = []
+        poller.new_entries_found.connect(entries.extend)
+        poller._poll_feed(feed)
+
+        assert len(entries) == 2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,24 @@ class TestFeed:
         assert d["sound_file"] is None
         assert d["last_poll_time"] is None
 
+    def test_to_dict_no_plaintext_credentials(self):
+        """to_dict must never include auth_user or auth_token."""
+        feed = Feed(
+            url="https://example.com/feed",
+            name="Auth Feed",
+            auth_user="admin",
+            auth_token="secret",
+        )
+        d = feed.to_dict()
+        assert "auth_user" not in d
+        assert "auth_token" not in d
+        assert d["has_auth"] is True
+
+    def test_to_dict_has_auth_false_when_no_creds(self, sample_feed):
+        """has_auth should be False when no credentials are set."""
+        d = sample_feed.to_dict()
+        assert d["has_auth"] is False
+
     def test_from_dict(self):
         data = {
             "url": "https://test.com/feed",
@@ -32,6 +50,18 @@ class TestFeed:
         feed = Feed.from_dict(data)
         assert feed.enabled is True
         assert feed.sound_file is None
+
+    def test_from_dict_legacy_plaintext_credentials(self):
+        """from_dict should still read legacy auth_user/auth_token for migration."""
+        data = {
+            "url": "https://test.com/feed",
+            "name": "Test",
+            "auth_user": "admin",
+            "auth_token": "secret",
+        }
+        feed = Feed.from_dict(data)
+        assert feed.auth_user == "admin"
+        assert feed.auth_token == "secret"
 
     def test_roundtrip(self, sample_feed):
         restored = Feed.from_dict(sample_feed.to_dict())


### PR DESCRIPTION
## Summary
- Credentials now stored in OS keyring (macOS Keychain, GNOME Keyring, Windows Credential Manager) instead of plaintext `config.json`
- Legacy plaintext credentials are automatically migrated to keyring on first load
- Feed poller refuses to send Basic auth over plain HTTP connections
- `keyring>=25.0.0` added as dependency

## Changes
- New `src/credential_store.py` — keyring-backed credential CRUD with HTTPS enforcement
- `Feed.to_dict()` no longer serializes `auth_user`/`auth_token`; uses `has_auth` flag instead
- `config.py` auto-migrates legacy plaintext creds on load
- `feed_poller.py` looks up credentials from keyring, rejects HTTP+auth
- `settings_dialog.py` stores/loads credentials via keyring

## Test plan
- [x] 9 credential store tests (store, get, delete, HTTPS enforcement)
- [x] 3 migration tests (plaintext→keyring, HTTP skip, no-op)
- [x] 3 auth poller tests (HTTP rejection, HTTPS success, no-auth HTTP allowed)
- [x] Updated model tests for `has_auth` flag and no plaintext serialization
- [x] All 61 tests passing
- [x] CI lint-and-test passing
- [x] CI builds passing (Linux, macOS, Windows)

Closes #5
Closes #17