### PR TITLE
fix: macOS DMG build failure (hdiutil Resource busy)

### DIFF
--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -9,7 +9,7 @@ if [ -f "assets/icon.icns" ]; then
 fi
 
 uv run pyinstaller \
-    --onefile \
+    --onedir \
     --windowed \
     --name Jinkies \
     ${ICON_FLAG} \
@@ -18,8 +18,12 @@ uv run pyinstaller \
 
 echo "==> Creating DMG..."
 if command -v hdiutil &> /dev/null; then
+    # Ensure all file handles from the build are released
+    sync
+    sleep 2
+
     mkdir -p dist/dmg_staging
-    cp -r dist/Jinkies.app dist/dmg_staging/ 2>/dev/null || cp dist/Jinkies dist/dmg_staging/
+    cp -r dist/Jinkies.app dist/dmg_staging/ 2>/dev/null || cp -r dist/Jinkies dist/dmg_staging/
     hdiutil create -volname "Jinkies" -srcfolder dist/dmg_staging -ov -format UDZO dist/Jinkies.dmg
     rm -rf dist/dmg_staging
     echo "==> Done: dist/Jinkies.dmg"


### PR DESCRIPTION
## Summary
- Switch PyInstaller from `--onefile` to `--onedir` mode for macOS, as recommended by PyInstaller (onefile + windowed is deprecated for .app bundles and will error in v7.0)
- Add `sync && sleep 2` before `hdiutil create` to ensure build file handles are released
- Fix `cp` to use `-r` for the onedir output directory

## Test plan
- [x] CI macOS build job completes successfully
- [x] `dist/Jinkies.dmg` is produced as an artifact
- [x] CI lint-and-test passing
- [x] CI builds passing (Linux, macOS, Windows)

Closes #24