### PR TITLE
Add linting and testing stage to CI before build occurs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Run Linter
+        run: uv run ruff check src tests
+
+      - name: Run tests
+        run: uv run pytest
+
       - name: Build (Unix)
         if: runner.os != 'Windows'
         run: |


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link the related issue(s). -->
<!-- Closes #ISSUE_NUMBER -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Tests only
- [ ] Documentation
- [x] CI / build / chore
- [ ] Breaking change (tick this AND one of the above)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My branch targets `main`
- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes with no new violations (`uv run ruff check src tests`)
- [x] New behaviour is covered by tests
- [x] Docstrings follow Google style on all new/modified public functions
- [x] Type annotations are present on all new public functions
