### PR TITLE
ensure config location exists

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -66,6 +66,7 @@ class Dashboard(QMainWindow):
         # Create store at default location if it doesnt exist
         self._entries_store_location = get_config_dir() / "store.json"
         if not self._entries_store_location.exists():
+            self._entries_store_location.parent.mkdir(parents=True, exist_ok=True)
             f = open(self._entries_store_location, "w")
             f.write('{"entries": []}')
             f.close()


### PR DESCRIPTION
## Summary

Fixes CI runner crashing due to lack of store.json and .config folder

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Tests only
- [ ] Documentation
- [x] CI / build / chore
- [ ] Breaking change (tick this AND one of the above)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] My branch targets `main`
- [x] All existing tests pass (`uv run pytest`)
- [x] Linter passes with no new violations (`uv run ruff check src tests`)
- [x] New behaviour is covered by tests
- [x] Docstrings follow Google style on all new/modified public functions
- [x] Type annotations are present on all new public functions
